### PR TITLE
Gopherize coding style + some improvements

### DIFF
--- a/header.go
+++ b/header.go
@@ -132,6 +132,11 @@ func (h *FALinkHeader) MarshalBinary() ([]byte, error) {
 
 //MarshalTo puts the byte sequence in the byte array given as b.
 func (h *FALinkHeader) MarshalTo(b []byte) error {
+	l := len(b)
+	if l < 64 {
+		return io.ErrUnexpectedEOF
+	}
+
 	copy(b, h.HType[:])
 	binary.BigEndian.PutUint32(b[4:], h.TFL)
 	binary.BigEndian.PutUint32(b[8:], h.SA)
@@ -160,6 +165,10 @@ func (h *FALinkHeader) MarshalTo(b []byte) error {
 	b[60] = h.LKS
 	b[61] = h.TW
 	binary.BigEndian.PutUint16(b[62:], h.RCT)
+
+	if l < h.MarshalLen() {
+		return io.ErrUnexpectedEOF
+	}
 	copy(b[64:h.MarshalLen()], h.Payload)
 
 	return nil

--- a/header.go
+++ b/header.go
@@ -13,7 +13,7 @@ import (
 
 // TCD definitions.
 const (
-	TCDToken = iota + 65000
+	TCDToken uint16 = iota + 65000
 	TCDCyclic
 	TCDParticipateRequest
 	TCDByteBlockReadRequest

--- a/header.go
+++ b/header.go
@@ -11,45 +11,45 @@ import (
 	"github.com/kazukiigeta/go-flnet/utils"
 )
 
-// TCD deficitions.
+// TCD definitions.
 const (
-	TcdToken = iota + 65000
-	TcdCyclic
-	TcdParticipateRequest
-	TcdByteBlockReadRequest
-	TcdByteBlockWriteRequest
+	TCDToken = iota + 65000
+	TCDCyclic
+	TCDParticipateRequest
+	TCDByteBlockReadRequest
+	TCDByteBlockWriteRequest
 )
 
 // FALinkHeader is a FL-net header.
 type FALinkHeader struct {
 	HType    [4]uint8
-	Tfl      uint32
-	Sa       uint32
-	Da       uint32
+	TFL      uint32
+	SA       uint32
+	DA       uint32
 	VSeq     uint32
 	Seq      uint32
-	MCtl     uint32
-	Uls      uint16
-	MSz      uint16
-	MAdd     uint32
-	Mft      uint8
-	MRlt     uint8
+	MCTL     uint32
+	ULS      uint16
+	MSZ      uint16
+	MADD     uint32
+	MFT      uint8
+	MRLT     uint8
 	Reserved uint16
-	Tcd      uint16
+	TCD      uint16
 	Ver      uint16
-	CAd1     uint16
-	CSz1     uint16
-	CAd2     uint16
-	CSz2     uint16
+	CAD1     uint16
+	CSZ1     uint16
+	CAD2     uint16
+	CSZ2     uint16
 	Mode     uint16
 	PType    uint8
 	Pri      uint8
-	Cbn      uint8
-	Tbn      uint8
+	CBN      uint8
+	TBN      uint8
 	BSize    uint16
-	Lks      uint8
-	Tw       uint8
-	Rct      uint16
+	LKS      uint8
+	TW       uint8
+	RCT      uint16
 	Payload  []byte
 }
 
@@ -91,32 +91,32 @@ func NewFALinkHeader(
 ) *FALinkHeader {
 	h := &FALinkHeader{}
 	h.HType = htype
-	h.Tfl = tfl
-	h.Sa = 0x00010000 | uint32(sna)
-	h.Da = 0x00010000 | uint32(dna)
+	h.TFL = tfl
+	h.SA = 0x00010000 | uint32(sna)
+	h.DA = 0x00010000 | uint32(dna)
 	h.VSeq = vseq
 	h.Seq = seq
-	h.MCtl = uint32((utils.BoolToUint(bct) << 31) + (utils.BoolToUint(ppt) << 30))
-	h.Uls = uls
-	h.MSz = msz
-	h.MAdd = madd
-	h.Mft = mft
-	h.MRlt = mrlt
+	h.MCTL = uint32((utils.BoolToUint(bct) << 31) + (utils.BoolToUint(ppt) << 30))
+	h.ULS = uls
+	h.MSZ = msz
+	h.MADD = madd
+	h.MFT = mft
+	h.MRLT = mrlt
 	h.Reserved = reserved
-	h.Tcd = tcd
+	h.TCD = tcd
 	h.Ver = ver
-	h.CAd1 = cad1
-	h.CSz1 = csz1
-	h.CAd2 = cad2
-	h.CSz2 = csz2
+	h.CAD1 = cad1
+	h.CSZ1 = csz1
+	h.CAD2 = cad2
+	h.CSZ2 = csz2
 	h.Mode = uint16((minver << 8) + (majver << 4) + utils.BoolToUint(tokmode))
 	h.PType = ptype
-	h.Cbn = cbn
-	h.Tbn = tbn
+	h.CBN = cbn
+	h.TBN = tbn
 	h.BSize = bsize
-	h.Lks = lks
-	h.Tw = tw
-	h.Rct = rct
+	h.LKS = lks
+	h.TW = tw
+	h.RCT = rct
 	h.Payload = payload
 
 	return h
@@ -134,33 +134,33 @@ func (h *FALinkHeader) MarshalBinary() ([]byte, error) {
 //MarshalTo puts the byte sequence in the byte array given as b.
 func (h *FALinkHeader) MarshalTo(b []byte) error {
 	copy(b, h.HType[:])
-	binary.BigEndian.PutUint32(b[4:], h.Tfl)
-	binary.BigEndian.PutUint32(b[8:], h.Sa)
-	binary.BigEndian.PutUint32(b[12:], h.Da)
+	binary.BigEndian.PutUint32(b[4:], h.TFL)
+	binary.BigEndian.PutUint32(b[8:], h.SA)
+	binary.BigEndian.PutUint32(b[12:], h.DA)
 	binary.BigEndian.PutUint32(b[16:], h.VSeq)
 	binary.BigEndian.PutUint32(b[20:], h.Seq)
-	binary.BigEndian.PutUint32(b[24:], h.MCtl)
-	binary.BigEndian.PutUint16(b[28:], h.Uls)
-	binary.BigEndian.PutUint16(b[30:], h.MSz)
-	binary.BigEndian.PutUint32(b[32:], h.MAdd)
-	b[36] = h.Mft
-	b[37] = h.MRlt
+	binary.BigEndian.PutUint32(b[24:], h.MCTL)
+	binary.BigEndian.PutUint16(b[28:], h.ULS)
+	binary.BigEndian.PutUint16(b[30:], h.MSZ)
+	binary.BigEndian.PutUint32(b[32:], h.MADD)
+	b[36] = h.MFT
+	b[37] = h.MRLT
 	binary.BigEndian.PutUint16(b[38:], h.Reserved)
-	binary.BigEndian.PutUint16(b[40:], h.Tcd)
+	binary.BigEndian.PutUint16(b[40:], h.TCD)
 	binary.BigEndian.PutUint16(b[42:], h.Ver)
-	binary.BigEndian.PutUint16(b[44:], h.CAd1)
-	binary.BigEndian.PutUint16(b[46:], h.CSz1)
-	binary.BigEndian.PutUint16(b[48:], h.CAd2)
-	binary.BigEndian.PutUint16(b[50:], h.CSz2)
+	binary.BigEndian.PutUint16(b[44:], h.CAD1)
+	binary.BigEndian.PutUint16(b[46:], h.CSZ1)
+	binary.BigEndian.PutUint16(b[48:], h.CAD2)
+	binary.BigEndian.PutUint16(b[50:], h.CSZ2)
 	binary.BigEndian.PutUint16(b[52:], h.Mode)
 	b[54] = h.PType
 	b[55] = h.Pri
-	b[56] = h.Cbn
-	b[57] = h.Tbn
+	b[56] = h.CBN
+	b[57] = h.TBN
 	binary.BigEndian.PutUint16(b[58:], h.BSize)
-	b[60] = h.Lks
-	b[61] = h.Tw
-	binary.BigEndian.PutUint16(b[62:], h.Rct)
+	b[60] = h.LKS
+	b[61] = h.TW
+	binary.BigEndian.PutUint16(b[62:], h.RCT)
 	copy(b[64:h.MarshalLen()], h.Payload)
 
 	return nil
@@ -186,33 +186,33 @@ func (h *FALinkHeader) UnmarshalBinary(b []byte) error {
 		return io.ErrUnexpectedEOF
 	}
 	copy(h.HType[:], b[:4])
-	h.Tfl = binary.BigEndian.Uint32(b[4:8])
-	h.Sa = binary.BigEndian.Uint32(b[8:12])
-	h.Da = binary.BigEndian.Uint32(b[12:16])
+	h.TFL = binary.BigEndian.Uint32(b[4:8])
+	h.SA = binary.BigEndian.Uint32(b[8:12])
+	h.DA = binary.BigEndian.Uint32(b[12:16])
 	h.VSeq = binary.BigEndian.Uint32(b[16:20])
 	h.Seq = binary.BigEndian.Uint32(b[20:24])
-	h.MCtl = binary.BigEndian.Uint32(b[24:28])
-	h.Uls = binary.BigEndian.Uint16(b[28:30])
-	h.MSz = binary.BigEndian.Uint16(b[30:32])
-	h.MAdd = binary.BigEndian.Uint32(b[32:36])
-	h.Mft = uint8(b[37])
-	h.MRlt = uint8(b[38])
+	h.MCTL = binary.BigEndian.Uint32(b[24:28])
+	h.ULS = binary.BigEndian.Uint16(b[28:30])
+	h.MSZ = binary.BigEndian.Uint16(b[30:32])
+	h.MADD = binary.BigEndian.Uint32(b[32:36])
+	h.MFT = uint8(b[37])
+	h.MRLT = uint8(b[38])
 	h.Reserved = binary.BigEndian.Uint16(b[38:40])
-	h.Tcd = binary.BigEndian.Uint16(b[40:42])
+	h.TCD = binary.BigEndian.Uint16(b[40:42])
 	h.Ver = binary.BigEndian.Uint16(b[42:44])
-	h.CAd1 = binary.BigEndian.Uint16(b[44:46])
-	h.CSz1 = binary.BigEndian.Uint16(b[46:48])
-	h.CAd2 = binary.BigEndian.Uint16(b[48:50])
-	h.CSz2 = binary.BigEndian.Uint16(b[50:52])
+	h.CAD1 = binary.BigEndian.Uint16(b[44:46])
+	h.CSZ1 = binary.BigEndian.Uint16(b[46:48])
+	h.CAD2 = binary.BigEndian.Uint16(b[48:50])
+	h.CSZ2 = binary.BigEndian.Uint16(b[50:52])
 	h.Mode = binary.BigEndian.Uint16(b[52:54])
 	h.PType = uint8(b[55])
 	h.Pri = uint8(b[56])
-	h.Cbn = uint8(b[57])
-	h.Tbn = uint8(b[58])
+	h.CBN = uint8(b[57])
+	h.TBN = uint8(b[58])
 	h.BSize = binary.BigEndian.Uint16(b[58:60])
-	h.Tbn = uint8(b[61])
-	h.Tbn = uint8(b[62])
-	h.Rct = binary.BigEndian.Uint16(b[62:64])
+	h.TBN = uint8(b[61])
+	h.TBN = uint8(b[62])
+	h.RCT = binary.BigEndian.Uint16(b[62:64])
 	h.Payload = b[64:]
 	return nil
 }

--- a/header.go
+++ b/header.go
@@ -89,37 +89,36 @@ func NewFALinkHeader(
 	rct uint16,
 	payload []byte,
 ) *FALinkHeader {
-	h := &FALinkHeader{}
-	h.HType = htype
-	h.TFL = tfl
-	h.SA = 0x00010000 | uint32(sna)
-	h.DA = 0x00010000 | uint32(dna)
-	h.VSeq = vseq
-	h.Seq = seq
-	h.MCTL = uint32((utils.BoolToUint(bct) << 31) + (utils.BoolToUint(ppt) << 30))
-	h.ULS = uls
-	h.MSZ = msz
-	h.MADD = madd
-	h.MFT = mft
-	h.MRLT = mrlt
-	h.Reserved = reserved
-	h.TCD = tcd
-	h.Ver = ver
-	h.CAD1 = cad1
-	h.CSZ1 = csz1
-	h.CAD2 = cad2
-	h.CSZ2 = csz2
-	h.Mode = uint16((minver << 8) + (majver << 4) + utils.BoolToUint(tokmode))
-	h.PType = ptype
-	h.CBN = cbn
-	h.TBN = tbn
-	h.BSize = bsize
-	h.LKS = lks
-	h.TW = tw
-	h.RCT = rct
-	h.Payload = payload
-
-	return h
+	return &FALinkHeader{
+		HType:    htype,
+		TFL:      tfl,
+		SA:       0x00010000 | uint32(sna),
+		DA:       0x00010000 | uint32(dna),
+		VSeq:     vseq,
+		Seq:      seq,
+		MCTL:     uint32((utils.BoolToUint(bct) << 31) + (utils.BoolToUint(ppt) << 30)),
+		ULS:      uls,
+		MSZ:      msz,
+		MADD:     madd,
+		MFT:      mft,
+		MRLT:     mrlt,
+		Reserved: reserved,
+		TCD:      tcd,
+		Ver:      ver,
+		CAD1:     cad1,
+		CSZ1:     csz1,
+		CAD2:     cad2,
+		CSZ2:     csz2,
+		Mode:     uint16((minver << 8) + (majver << 4) + utils.BoolToUint(tokmode)),
+		PType:    ptype,
+		CBN:      cbn,
+		TBN:      tbn,
+		BSize:    bsize,
+		LKS:      lks,
+		TW:       tw,
+		RCT:      rct,
+		Payload:  payload,
+	}
 }
 
 // MarshalBinary returns the byte sequence generated from a FALinkHeader instance.

--- a/messages.go
+++ b/messages.go
@@ -31,7 +31,7 @@ func NewToken() *Token {
 			0, 0, // ULS, M_SZ
 			0,       // M_ADD
 			0, 0, 0, // MFT, M_RLT, reserved
-			TcdToken, 0, // TCD, VER
+			TCDToken, 0, // TCD, VER
 			0, 0, // C_AD1, C_SZ1
 			0, 0, // C_AD2, C_SZ2
 			0, 3, true, 0x80, 0, // MODE, P_TYPE, PRI


### PR DESCRIPTION
9726ebe
We usually capitalize acronyms and the pieces of abbreviated words.
https://github.com/golang/go/wiki/CodeReviewComments#initialisms

ba90345
Untyped constants sometimes cause unexpected behavior. Better giving a type if feasible.

a1720b3
No need to create a variable for a object that returns without any additional manipulation (I think it does not affect the performance, though).

551c54b
MarshalTo may cause panic when it's called directly (not from MarshalBinary).
